### PR TITLE
Implement Basic Media Rendering - Static

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -262,6 +262,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9dbc3a507a82b17ba0d98f6ce8fd6954ea0c8152e98009d36a40d8dcc8ce078a"
 
 [[package]]
+name = "ashpd"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2f3f79755c74fd155000314eb349864caa787c6592eace6c6882dad873d9c39"
+dependencies = [
+ "async-fs",
+ "async-net",
+ "enumflags2",
+ "futures-channel",
+ "futures-util",
+ "rand 0.9.2",
+ "raw-window-handle",
+ "serde",
+ "serde_repr",
+ "url",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-protocols",
+ "zbus",
+]
+
+[[package]]
 name = "assign"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -318,6 +340,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-fs"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8034a681df4aed8b8edbd7fbe472401ecf009251c8b40556b304567052e294c5"
+dependencies = [
+ "async-lock",
+ "blocking",
+ "futures-lite",
+]
+
+[[package]]
 name = "async-io"
 version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -344,6 +377,17 @@ dependencies = [
  "event-listener",
  "event-listener-strategy",
  "pin-project-lite",
+]
+
+[[package]]
+name = "async-net"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b948000fad4873c1c9339d60f2623323a0cfd3816e5181033c6a5cb68b2accf7"
+dependencies = [
+ "async-io",
+ "blocking",
+ "futures-lite",
 ]
 
 [[package]]
@@ -1459,6 +1503,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "89a09f22a6c6069a18470eb92d2298acf25463f14256d24778e1230d789a2aec"
 dependencies = [
  "bitflags 2.11.0",
+ "block2 0.6.2",
+ "libc",
  "objc2 0.6.3",
 ]
 
@@ -4853,6 +4899,7 @@ dependencies = [
  "arboard",
  "backend-core",
  "backend-matrix",
+ "rfd",
  "serde",
  "serde_json",
  "slint",
@@ -4967,6 +5014,12 @@ dependencies = [
  "rustix 1.1.3",
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "pollster"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f3a9f18d041e6d0e102a0a46750538147e5e8992d3b4873aaafee2520b00ce3"
 
 [[package]]
 name = "poly1305"
@@ -5526,6 +5579,30 @@ dependencies = [
  "tiny-skia",
  "usvg",
  "zune-jpeg 0.5.12",
+]
+
+[[package]]
+name = "rfd"
+version = "0.15.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef2bee61e6cffa4635c72d7d81a84294e28f0930db0ddcb0f66d10244674ebed"
+dependencies = [
+ "ashpd",
+ "block2 0.6.2",
+ "dispatch2",
+ "js-sys",
+ "log",
+ "objc2 0.6.3",
+ "objc2-app-kit 0.3.2",
+ "objc2-core-foundation",
+ "objc2-foundation 0.3.2",
+ "pollster",
+ "raw-window-handle",
+ "urlencoding",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -7976,6 +8053,15 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.60.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
@@ -8792,6 +8878,7 @@ dependencies = [
  "endi",
  "enumflags2",
  "serde",
+ "url",
  "winnow",
  "zvariant_derive",
  "zvariant_utils",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4899,6 +4899,7 @@ dependencies = [
  "arboard",
  "backend-core",
  "backend-matrix",
+ "image",
  "rfd",
  "serde",
  "serde_json",

--- a/apps/pikachat-desktop/Cargo.toml
+++ b/apps/pikachat-desktop/Cargo.toml
@@ -10,6 +10,7 @@ build = "build.rs"
 arboard = "3.6.1"
 backend-core = { path = "../../crates/backend-core" }
 backend-matrix = { path = "../../crates/backend-matrix" }
+image = { version = "0.25.9", default-features = false, features = ["gif"] }
 rfd = "0.15.4"
 serde.workspace = true
 serde_json.workspace = true

--- a/apps/pikachat-desktop/Cargo.toml
+++ b/apps/pikachat-desktop/Cargo.toml
@@ -10,9 +10,10 @@ build = "build.rs"
 arboard = "3.6.1"
 backend-core = { path = "../../crates/backend-core" }
 backend-matrix = { path = "../../crates/backend-matrix" }
+rfd = "0.15.4"
 serde.workspace = true
 serde_json.workspace = true
-slint = { version = "1.15.1", default-features = false, features = ["std", "compat-1-2", "backend-winit", "backend-winit-wayland", "backend-winit-x11", "renderer-femtovg"] }
+slint = { version = "1.15.1", default-features = false, features = ["std", "compat-1-2", "backend-winit", "backend-winit-wayland", "backend-winit-x11", "renderer-femtovg", "image-default-formats"] }
 tokio.workspace = true
 tracing.workspace = true
 tracing-subscriber.workspace = true

--- a/apps/pikachat-desktop/src/gif_player.rs
+++ b/apps/pikachat-desktop/src/gif_player.rs
@@ -1,0 +1,665 @@
+//! GIF decode and playback controller for desktop media rows.
+
+use std::{
+    collections::{HashMap, HashSet},
+    fs,
+    io::Cursor,
+    path::Path,
+    sync::Arc,
+};
+
+use image::codecs::gif::GifDecoder;
+use image::{AnimationDecoder, ImageDecoder};
+
+/// Maximum number of decoded frames per GIF.
+pub const MAX_GIF_FRAMES: usize = 300;
+/// Maximum decoded RGBA bytes budget per GIF.
+pub const MAX_DECODED_BYTES_PER_GIF: u64 = 128 * 1024 * 1024;
+/// Maximum allowed frame dimension in pixels.
+pub const MAX_FRAME_DIMENSION: u32 = 4096;
+/// Minimum frame delay used for playback scheduling.
+pub const MIN_FRAME_DELAY_MS: u64 = 33;
+/// Maximum rows animated concurrently.
+pub const MAX_CONCURRENT_ANIMATED_ROWS: usize = 3;
+/// UI visibility ping cadence.
+pub const VISIBLE_PING_INTERVAL_MS: u64 = 250;
+/// Row visibility timeout after the last ping.
+pub const VISIBLE_STALE_TIMEOUT_MS: u64 = 750;
+
+/// UI-facing hint for guardrail fallback.
+pub const GUARDRAIL_FALLBACK_REASON: &str = "GIF shown as static (too large to animate)";
+
+const DECODE_FALLBACK_REASON: &str = "GIF shown as static (failed to decode animation)";
+const DEFAULT_DECODE_CACHE_CAPACITY: usize = 64;
+
+/// Decoded media result for GIF-capable sources.
+#[derive(Clone)]
+pub enum GifDecodeResult {
+    /// Fully decoded animated GIF data.
+    Animated {
+        frames: Vec<slint::Image>,
+        delays_ms: Vec<u64>,
+        /// GIF loop metadata. `None` means unknown or infinite.
+        loop_count: Option<u32>,
+    },
+    /// Static fallback when animation is blocked by guardrails/decode issues.
+    StaticFallback {
+        first_frame: slint::Image,
+        reason: String,
+    },
+    /// Input is not a GIF.
+    NotGif,
+}
+
+/// Per-tick frame update emitted by [`GifPlaybackController::tick`].
+#[derive(Clone)]
+pub struct GifFrameUpdate {
+    pub media_key: String,
+    pub frame: slint::Image,
+}
+
+/// Decode GIF bytes using the `image` crate animated GIF APIs.
+pub fn decode_gif_bytes(bytes: &[u8]) -> GifDecodeResult {
+    if !looks_like_gif(bytes) {
+        return GifDecodeResult::NotGif;
+    }
+
+    let decoder = match GifDecoder::new(Cursor::new(bytes)) {
+        Ok(decoder) => decoder,
+        Err(_) => return GifDecodeResult::NotGif,
+    };
+
+    let (logical_width, logical_height) = decoder.dimensions();
+    let logical_dimension_guardrail =
+        logical_width > MAX_FRAME_DIMENSION || logical_height > MAX_FRAME_DIMENSION;
+
+    let mut frame_count = 0usize;
+    let mut decoded_bytes = 0u64;
+    let mut first_frame: Option<slint::Image> = None;
+    let mut frames = Vec::new();
+    let mut delays_ms = Vec::new();
+    let mut frame_iter = decoder.into_frames();
+
+    while let Some(frame_result) = frame_iter.next() {
+        let frame = match frame_result {
+            Ok(frame) => frame,
+            Err(_) => return fallback_or_not_gif(first_frame, DECODE_FALLBACK_REASON),
+        };
+
+        let frame_delay_ms = normalize_delay_ms(frame.delay());
+        let rgba = frame.into_buffer();
+        let frame_image = rgba_to_slint_image(&rgba);
+        if first_frame.is_none() {
+            first_frame = Some(frame_image.clone());
+        }
+
+        frame_count = frame_count.saturating_add(1);
+        decoded_bytes = decoded_bytes
+            .saturating_add(decoded_frame_bytes(rgba.width(), rgba.height()).unwrap_or(u64::MAX));
+
+        let frame_dimension_guardrail =
+            rgba.width() > MAX_FRAME_DIMENSION || rgba.height() > MAX_FRAME_DIMENSION;
+        if logical_dimension_guardrail
+            || frame_dimension_guardrail
+            || frame_count > MAX_GIF_FRAMES
+            || decoded_bytes > MAX_DECODED_BYTES_PER_GIF
+        {
+            return fallback_or_not_gif(first_frame, GUARDRAIL_FALLBACK_REASON);
+        }
+
+        frames.push(frame_image);
+        delays_ms.push(frame_delay_ms);
+    }
+
+    if frames.is_empty() {
+        return GifDecodeResult::NotGif;
+    }
+
+    GifDecodeResult::Animated {
+        frames,
+        delays_ms,
+        // The image crate decoder does not currently expose GIF loop extension metadata.
+        loop_count: None,
+    }
+}
+
+/// Main-thread playback controller for timeline/fullscreen GIF rows.
+pub struct GifPlaybackController {
+    decode_cache: DecodedGifCache,
+    rows: HashMap<String, RowPlaybackState>,
+}
+
+impl Default for GifPlaybackController {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl GifPlaybackController {
+    /// Create a controller with a default decoded GIF cache size.
+    pub fn new() -> Self {
+        Self::with_cache_capacity(DEFAULT_DECODE_CACHE_CAPACITY)
+    }
+
+    /// Create a controller with an explicit decoded GIF cache size.
+    pub fn with_cache_capacity(cache_capacity: usize) -> Self {
+        Self {
+            decode_cache: DecodedGifCache::new(cache_capacity.max(1)),
+            rows: HashMap::new(),
+        }
+    }
+
+    /// Record a visibility ping for a row/media key.
+    pub fn register_visibility_ping(&mut self, media_key: impl Into<String>, now_ms: u64) {
+        let row = self.rows.entry(media_key.into()).or_default();
+        row.last_visibility_ping_ms = Some(now_ms);
+    }
+
+    /// Attach a decoded source path to a row/media key.
+    pub fn attach_source(&mut self, media_key: impl Into<String>, file_path: impl AsRef<Path>) {
+        let media_key = media_key.into();
+        let source_path = file_path.as_ref();
+        let source_cache_key = source_path.to_string_lossy().into_owned();
+        let _decoded = self
+            .decode_cache
+            .get_or_load(source_cache_key.clone(), || decode_gif_file(source_path));
+
+        let row = self.rows.entry(media_key).or_default();
+        row.source_cache_key = Some(source_cache_key);
+        row.current_frame_index = 0;
+        row.completed_loops = 0;
+        row.next_frame_due_ms = None;
+        row.is_active = false;
+    }
+
+    /// Advance animation state and emit changed row frames.
+    pub fn tick(&mut self, now_ms: u64) -> Vec<GifFrameUpdate> {
+        let mut candidates: Vec<(String, u64)> = self
+            .rows
+            .iter()
+            .filter_map(|(media_key, row)| {
+                let last_ping = row.last_visibility_ping_ms?;
+                if now_ms.saturating_sub(last_ping) > VISIBLE_STALE_TIMEOUT_MS {
+                    return None;
+                }
+
+                let source_key = row.source_cache_key.as_deref()?;
+                let decoded = self.decode_cache.peek(source_key)?;
+                match decoded.as_ref() {
+                    GifDecodeResult::Animated { frames, .. } if frames.len() > 1 => {
+                        Some((media_key.clone(), last_ping))
+                    }
+                    _ => None,
+                }
+            })
+            .collect();
+
+        candidates.sort_by(|a, b| b.1.cmp(&a.1).then_with(|| a.0.cmp(&b.0)));
+        candidates.truncate(MAX_CONCURRENT_ANIMATED_ROWS);
+        let active_order: Vec<String> = candidates.into_iter().map(|(key, _)| key).collect();
+        let active_set: HashSet<String> = active_order.iter().cloned().collect();
+
+        for (media_key, row) in &mut self.rows {
+            if !active_set.contains(media_key) {
+                row.is_active = false;
+                row.next_frame_due_ms = None;
+            }
+        }
+
+        let mut updates = Vec::new();
+        for media_key in active_order {
+            let Some(source_cache_key) = self
+                .rows
+                .get(&media_key)
+                .and_then(|row| row.source_cache_key.clone())
+            else {
+                continue;
+            };
+            let Some(decoded) = self.decode_cache.get(&source_cache_key) else {
+                continue;
+            };
+            let GifDecodeResult::Animated {
+                frames,
+                delays_ms,
+                loop_count,
+            } = decoded.as_ref()
+            else {
+                continue;
+            };
+            if frames.len() <= 1 {
+                continue;
+            }
+
+            let Some(row) = self.rows.get_mut(&media_key) else {
+                continue;
+            };
+            if row.current_frame_index >= frames.len() {
+                row.current_frame_index = 0;
+                row.completed_loops = 0;
+            }
+
+            if !row.is_active {
+                row.is_active = true;
+                row.next_frame_due_ms = Some(
+                    now_ms.saturating_add(delay_for_index(delays_ms, row.current_frame_index)),
+                );
+            }
+
+            let mut next_due = row.next_frame_due_ms.unwrap_or_else(|| {
+                now_ms.saturating_add(delay_for_index(delays_ms, row.current_frame_index))
+            });
+            let mut changed = false;
+
+            while now_ms >= next_due {
+                if !advance_row_frame(row, frames.len(), *loop_count) {
+                    row.next_frame_due_ms = None;
+                    break;
+                }
+                changed = true;
+                next_due =
+                    next_due.saturating_add(delay_for_index(delays_ms, row.current_frame_index));
+                row.next_frame_due_ms = Some(next_due);
+            }
+
+            if row.next_frame_due_ms.is_some() {
+                row.next_frame_due_ms = Some(next_due);
+            }
+
+            if changed {
+                updates.push(GifFrameUpdate {
+                    media_key,
+                    frame: frames[row.current_frame_index].clone(),
+                });
+            }
+        }
+
+        updates
+    }
+
+    /// Read the current frame to render for a media key.
+    pub fn current_frame_for(&self, media_key: &str) -> Option<slint::Image> {
+        let row = self.rows.get(media_key)?;
+        let source_cache_key = row.source_cache_key.as_deref()?;
+        let decoded = self.decode_cache.peek(source_cache_key)?;
+
+        match decoded.as_ref() {
+            GifDecodeResult::Animated { frames, .. } => {
+                let frame_index = row.current_frame_index.min(frames.len().saturating_sub(1));
+                frames.get(frame_index).cloned()
+            }
+            GifDecodeResult::StaticFallback { first_frame, .. } => Some(first_frame.clone()),
+            GifDecodeResult::NotGif => None,
+        }
+    }
+
+    /// Read a static-fallback hint for a media key, if present.
+    pub fn hint_for(&self, media_key: &str) -> Option<String> {
+        let row = self.rows.get(media_key)?;
+        let source_cache_key = row.source_cache_key.as_deref()?;
+        let decoded = self.decode_cache.peek(source_cache_key)?;
+        match decoded.as_ref() {
+            GifDecodeResult::StaticFallback { reason, .. } => Some(reason.clone()),
+            _ => None,
+        }
+    }
+}
+
+fn advance_row_frame(
+    row: &mut RowPlaybackState,
+    frame_count: usize,
+    loop_count: Option<u32>,
+) -> bool {
+    if frame_count <= 1 {
+        return false;
+    }
+    if row.current_frame_index + 1 < frame_count {
+        row.current_frame_index += 1;
+        return true;
+    }
+
+    if let Some(max_loops) = loop_count {
+        if row.completed_loops.saturating_add(1) >= max_loops {
+            row.current_frame_index = frame_count - 1;
+            return false;
+        }
+    }
+
+    row.completed_loops = row.completed_loops.saturating_add(1);
+    row.current_frame_index = 0;
+    true
+}
+
+fn delay_for_index(delays_ms: &[u64], frame_index: usize) -> u64 {
+    delays_ms
+        .get(frame_index)
+        .copied()
+        .unwrap_or(MIN_FRAME_DELAY_MS)
+        .max(MIN_FRAME_DELAY_MS)
+}
+
+fn decode_gif_file(path: &Path) -> GifDecodeResult {
+    match fs::read(path) {
+        Ok(bytes) => decode_gif_bytes(&bytes),
+        Err(_) => GifDecodeResult::NotGif,
+    }
+}
+
+fn decoded_frame_bytes(width: u32, height: u32) -> Option<u64> {
+    u64::from(width)
+        .checked_mul(u64::from(height))
+        .and_then(|pixels| pixels.checked_mul(4))
+}
+
+fn looks_like_gif(bytes: &[u8]) -> bool {
+    bytes.len() >= 6 && (&bytes[..6] == b"GIF87a" || &bytes[..6] == b"GIF89a")
+}
+
+fn normalize_delay_ms(delay: image::Delay) -> u64 {
+    let (numerator, denominator) = delay.numer_denom_ms();
+    if denominator == 0 {
+        return MIN_FRAME_DELAY_MS;
+    }
+    let denominator = u64::from(denominator);
+    let millis = u64::from(numerator).saturating_add(denominator.saturating_sub(1)) / denominator;
+    millis.max(MIN_FRAME_DELAY_MS)
+}
+
+fn rgba_to_slint_image(rgba: &image::RgbaImage) -> slint::Image {
+    let buffer = slint::SharedPixelBuffer::<slint::Rgba8Pixel>::clone_from_slice(
+        rgba.as_raw(),
+        rgba.width(),
+        rgba.height(),
+    );
+    slint::Image::from_rgba8(buffer)
+}
+
+fn fallback_or_not_gif(first_frame: Option<slint::Image>, reason: &str) -> GifDecodeResult {
+    first_frame
+        .map(|first_frame| GifDecodeResult::StaticFallback {
+            first_frame,
+            reason: reason.to_owned(),
+        })
+        .unwrap_or(GifDecodeResult::NotGif)
+}
+
+struct DecodedGifCache {
+    capacity: usize,
+    access_clock: u64,
+    entries: HashMap<String, CachedDecodeEntry>,
+}
+
+struct CachedDecodeEntry {
+    decoded: Arc<GifDecodeResult>,
+    last_access: u64,
+}
+
+impl DecodedGifCache {
+    fn new(capacity: usize) -> Self {
+        Self {
+            capacity: capacity.max(1),
+            access_clock: 0,
+            entries: HashMap::new(),
+        }
+    }
+
+    fn peek(&self, key: &str) -> Option<&Arc<GifDecodeResult>> {
+        self.entries.get(key).map(|entry| &entry.decoded)
+    }
+
+    fn get(&mut self, key: &str) -> Option<Arc<GifDecodeResult>> {
+        let entry = self.entries.get_mut(key)?;
+        self.access_clock = self.access_clock.saturating_add(1);
+        entry.last_access = self.access_clock;
+        Some(Arc::clone(&entry.decoded))
+    }
+
+    fn get_or_load<F>(&mut self, key: String, load: F) -> Arc<GifDecodeResult>
+    where
+        F: FnOnce() -> GifDecodeResult,
+    {
+        if let Some(hit) = self.get(&key) {
+            return hit;
+        }
+
+        let decoded = Arc::new(load());
+        self.access_clock = self.access_clock.saturating_add(1);
+        self.entries.insert(
+            key,
+            CachedDecodeEntry {
+                decoded: Arc::clone(&decoded),
+                last_access: self.access_clock,
+            },
+        );
+        self.evict_if_needed();
+        decoded
+    }
+
+    fn evict_if_needed(&mut self) {
+        while self.entries.len() > self.capacity {
+            let Some(evict_key) = self
+                .entries
+                .iter()
+                .min_by_key(|(_, entry)| entry.last_access)
+                .map(|(key, _)| key.clone())
+            else {
+                break;
+            };
+            self.entries.remove(&evict_key);
+        }
+    }
+}
+
+#[derive(Default)]
+struct RowPlaybackState {
+    source_cache_key: Option<String>,
+    last_visibility_ping_ms: Option<u64>,
+    current_frame_index: usize,
+    completed_loops: u32,
+    next_frame_due_ms: Option<u64>,
+    is_active: bool,
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{
+        collections::HashSet,
+        fs,
+        path::{Path, PathBuf},
+        sync::atomic::{AtomicU64, Ordering},
+    };
+
+    use image::codecs::gif::{GifEncoder, Repeat};
+    use image::{Delay, Frame as ImageFrame, Rgba, RgbaImage};
+
+    use super::*;
+
+    #[test]
+    fn decode_guardrails_and_fallback() {
+        let many_frames = vec![10; MAX_GIF_FRAMES + 1];
+        let bytes = build_test_gif(2, 2, &many_frames);
+        match decode_gif_bytes(&bytes) {
+            GifDecodeResult::StaticFallback {
+                first_frame,
+                reason,
+            } => {
+                assert_eq!(reason, GUARDRAIL_FALLBACK_REASON);
+                let rgba = first_frame
+                    .to_rgba8()
+                    .expect("first frame should be readable");
+                assert_eq!(rgba.width(), 2);
+                assert_eq!(rgba.height(), 2);
+            }
+            _ => panic!("expected static fallback when frame count exceeds guardrail"),
+        }
+
+        let oversized = build_test_gif(MAX_FRAME_DIMENSION + 1, 1, &[10]);
+        assert!(matches!(
+            decode_gif_bytes(&oversized),
+            GifDecodeResult::StaticFallback { reason, .. } if reason == GUARDRAIL_FALLBACK_REASON
+        ));
+
+        assert!(matches!(
+            decode_gif_bytes(b"not-a-gif"),
+            GifDecodeResult::NotGif
+        ));
+    }
+
+    #[test]
+    fn delay_normalization_applies_minimum_delay() {
+        let bytes = build_test_gif(1, 1, &[0, 10, 50]);
+        match decode_gif_bytes(&bytes) {
+            GifDecodeResult::Animated { delays_ms, .. } => {
+                assert_eq!(delays_ms, vec![MIN_FRAME_DELAY_MS, MIN_FRAME_DELAY_MS, 50]);
+            }
+            _ => panic!("expected animated decode result"),
+        }
+    }
+
+    #[test]
+    fn visibility_timeout_pauses_rows() {
+        let gif_file = TempGifFile::new(&build_test_gif(1, 1, &[40, 40, 40]));
+        let mut controller = GifPlaybackController::with_cache_capacity(8);
+        controller.attach_source("row-1", gif_file.path());
+
+        assert_eq!(
+            first_pixel_red(
+                &controller
+                    .current_frame_for("row-1")
+                    .expect("initial frame")
+            ),
+            0
+        );
+
+        controller.register_visibility_ping("row-1", 0);
+        assert!(controller.tick(0).is_empty());
+        let updates = controller.tick(40);
+        assert_eq!(updates.len(), 1);
+        assert_eq!(
+            first_pixel_red(
+                &controller
+                    .current_frame_for("row-1")
+                    .expect("advanced frame should exist")
+            ),
+            80
+        );
+
+        let stale_tick = VISIBLE_STALE_TIMEOUT_MS + 100;
+        assert!(controller.tick(stale_tick).is_empty());
+        assert_eq!(
+            first_pixel_red(
+                &controller
+                    .current_frame_for("row-1")
+                    .expect("stale row should keep last frame")
+            ),
+            80
+        );
+        assert!(controller.tick(stale_tick + 1000).is_empty());
+        assert_eq!(
+            first_pixel_red(
+                &controller
+                    .current_frame_for("row-1")
+                    .expect("stale row should still be paused")
+            ),
+            80
+        );
+    }
+
+    #[test]
+    fn active_row_cap_limits_concurrent_animation() {
+        let gif_file = TempGifFile::new(&build_test_gif(1, 1, &[40, 40]));
+        let mut controller = GifPlaybackController::with_cache_capacity(8);
+
+        for key in ["row-a", "row-b", "row-c", "row-d"] {
+            controller.attach_source(key, gif_file.path());
+            controller.register_visibility_ping(key, 0);
+        }
+
+        assert!(controller.tick(0).is_empty());
+        let updates = controller.tick(40);
+        assert_eq!(updates.len(), MAX_CONCURRENT_ANIMATED_ROWS);
+        let mut updated_keys: Vec<&str> = updates
+            .iter()
+            .map(|update| update.media_key.as_str())
+            .collect();
+        updated_keys.sort_unstable();
+        assert_eq!(updated_keys, vec!["row-a", "row-b", "row-c"]);
+        assert_eq!(
+            first_pixel_red(
+                &controller
+                    .current_frame_for("row-d")
+                    .expect("row-d should have first frame")
+            ),
+            0
+        );
+
+        controller.register_visibility_ping("row-d", 100);
+        let _ = controller.tick(100);
+        let updates = controller.tick(140);
+        let updated_keys: HashSet<&str> = updates
+            .iter()
+            .map(|update| update.media_key.as_str())
+            .collect();
+        assert!(updated_keys.contains("row-d"));
+        assert!(!updated_keys.contains("row-c"));
+    }
+
+    fn build_test_gif(width: u32, height: u32, delays_ms: &[u32]) -> Vec<u8> {
+        let mut out = Vec::new();
+        {
+            let mut encoder = GifEncoder::new(&mut out);
+            encoder
+                .set_repeat(Repeat::Infinite)
+                .expect("repeat metadata should be writable");
+
+            let frames = delays_ms.iter().enumerate().map(|(idx, delay_ms)| {
+                let mut rgba = RgbaImage::new(width, height);
+                let red = ((idx as u16 * 80) % 256) as u8;
+                for pixel in rgba.pixels_mut() {
+                    *pixel = Rgba([red, 0, 0, 255]);
+                }
+                ImageFrame::from_parts(rgba, 0, 0, Delay::from_numer_denom_ms(*delay_ms, 1))
+            });
+            encoder
+                .encode_frames(frames)
+                .expect("test gif encoding should succeed");
+        }
+        out
+    }
+
+    fn first_pixel_red(image: &slint::Image) -> u8 {
+        let rgba = image
+            .to_rgba8()
+            .expect("test image should be convertible to rgba");
+        rgba.as_slice()
+            .first()
+            .expect("test image should contain at least one pixel")
+            .r
+    }
+
+    struct TempGifFile {
+        path: PathBuf,
+    }
+
+    impl TempGifFile {
+        fn new(bytes: &[u8]) -> Self {
+            static NEXT_ID: AtomicU64 = AtomicU64::new(1);
+            let id = NEXT_ID.fetch_add(1, Ordering::Relaxed);
+            let path = std::env::temp_dir().join(format!(
+                "pikachat-gif-player-test-{}-{id}.gif",
+                std::process::id()
+            ));
+            fs::write(&path, bytes).expect("should write temp gif");
+            Self { path }
+        }
+
+        fn path(&self) -> &Path {
+            &self.path
+        }
+    }
+
+    impl Drop for TempGifFile {
+        fn drop(&mut self) {
+            let _ = fs::remove_file(&self.path);
+        }
+    }
+}

--- a/apps/pikachat-desktop/src/main.rs
+++ b/apps/pikachat-desktop/src/main.rs
@@ -1,26 +1,83 @@
 mod auth_profile;
 mod bridge;
 mod config;
+mod gif_player;
 mod logging;
 mod media_cache;
 mod state;
 
-use std::sync::Arc;
+use std::{
+    cell::RefCell,
+    collections::{HashMap, HashSet},
+    path::Path,
+    rc::Rc,
+    sync::Arc,
+    time::{Duration, Instant},
+};
 
 use backend_core::types::RoomMembership;
 use backend_matrix::{MatrixFrontendAdapter, spawn_runtime};
 use bridge::{DesktopBridge, UiUpdateCallback};
 use config::DesktopConfig;
+use gif_player::{GifPlaybackController, MIN_FRAME_DELAY_MS, VISIBLE_PING_INTERVAL_MS};
+use slint::Model;
 use state::{DesktopSnapshot, clamp_sidebar_width};
-use tracing::{debug, error, info, trace};
+use tracing::{debug, error, info, trace, warn};
 
 slint::include_modules!();
+
+thread_local! {
+    static UI_RUNTIME_STATE: RefCell<Option<UiRuntimeState>> = const { RefCell::new(None) };
+}
+
+struct UiRuntimeState {
+    started_at: Instant,
+    messages_model: Rc<slint::VecModel<MessageRow>>,
+    media_row_index_by_key: HashMap<String, usize>,
+    gif_controller: GifPlaybackController,
+    attached_gif_sources: HashMap<String, String>,
+    fullscreen_media_key: Option<String>,
+}
+
+impl UiRuntimeState {
+    fn new(messages_model: Rc<slint::VecModel<MessageRow>>) -> Self {
+        Self {
+            started_at: Instant::now(),
+            messages_model,
+            media_row_index_by_key: HashMap::new(),
+            gif_controller: GifPlaybackController::new(),
+            attached_gif_sources: HashMap::new(),
+            fullscreen_media_key: None,
+        }
+    }
+
+    fn now_ms(&self) -> u64 {
+        let elapsed_ms = self.started_at.elapsed().as_millis();
+        elapsed_ms.min(u128::from(u64::MAX)) as u64
+    }
+}
 
 fn main() -> Result<(), slint::PlatformError> {
     logging::init();
     info!("starting pikachat-desktop");
 
     let ui = MainWindow::new()?;
+    initialize_ui_runtime(&ui);
+
+    let gif_tick_timer = slint::Timer::default();
+    let scheduler_tick_ms = MIN_FRAME_DELAY_MS.min(VISIBLE_PING_INTERVAL_MS);
+    {
+        let weak = ui.as_weak();
+        gif_tick_timer.start(
+            slint::TimerMode::Repeated,
+            Duration::from_millis(scheduler_tick_ms),
+            move || {
+                if let Some(ui) = weak.upgrade() {
+                    run_gif_scheduler_tick(&ui);
+                }
+            },
+        );
+    }
 
     // Menu callbacks are always available, regardless of backend startup outcome.
     let weak = ui.as_weak();
@@ -180,6 +237,25 @@ fn main() -> Result<(), slint::PlatformError> {
                     bridge.remove_outgoing_media(local_id.to_string());
                 });
             }
+            ui.on_gif_visible_ping(move |media_key| {
+                register_gif_visibility_ping(media_key.as_str());
+            });
+            {
+                let weak = ui.as_weak();
+                ui.on_media_screen_open_requested(move |media_key| {
+                    if let Some(ui) = weak.upgrade() {
+                        open_media_screen(&ui, media_key.as_str());
+                    }
+                });
+            }
+            {
+                let weak = ui.as_weak();
+                ui.on_media_screen_close_requested(move || {
+                    if let Some(ui) = weak.upgrade() {
+                        close_media_screen(&ui);
+                    }
+                });
+            }
             {
                 let bridge = Arc::clone(&spawned_bridge);
                 ui.on_timeline_scrolled(move |viewport_y| {
@@ -256,6 +332,9 @@ fn main() -> Result<(), slint::PlatformError> {
             ui.on_media_retry_requested(|_| {});
             ui.on_outgoing_media_retry_requested(|_| {});
             ui.on_outgoing_media_remove_requested(|_| {});
+            ui.on_gif_visible_ping(|_| {});
+            ui.on_media_screen_open_requested(|_| {});
+            ui.on_media_screen_close_requested(|| {});
             ui.on_timeline_scrolled(|_| {});
             ui.on_security_status_requested(|| {});
             ui.on_backup_identity_requested(|| {});
@@ -269,9 +348,120 @@ fn main() -> Result<(), slint::PlatformError> {
 
     let run_result = ui.run();
     info!("ui event loop exited");
+    drop(gif_tick_timer);
     drop(bridge);
     drop(runtime);
     run_result
+}
+
+fn initialize_ui_runtime(ui: &MainWindow) {
+    let messages_model = Rc::new(slint::VecModel::from(Vec::<MessageRow>::new()));
+    ui.set_messages(messages_model.clone().into());
+    UI_RUNTIME_STATE.with(|slot| {
+        *slot.borrow_mut() = Some(UiRuntimeState::new(messages_model));
+    });
+}
+
+fn with_ui_runtime_mut<R>(f: impl FnOnce(&mut UiRuntimeState) -> R) -> Option<R> {
+    UI_RUNTIME_STATE.with(|slot| {
+        let mut borrow = slot.borrow_mut();
+        let runtime = borrow.as_mut()?;
+        Some(f(runtime))
+    })
+}
+
+fn register_gif_visibility_ping(media_key: &str) {
+    let media_key = media_key.trim();
+    if media_key.is_empty() {
+        return;
+    }
+    let _ = with_ui_runtime_mut(|runtime| {
+        let now_ms = runtime.now_ms();
+        runtime
+            .gif_controller
+            .register_visibility_ping(media_key.to_owned(), now_ms);
+    });
+}
+
+fn open_media_screen(ui: &MainWindow, media_key: &str) {
+    let media_key = media_key.trim();
+    if media_key.is_empty() {
+        return;
+    }
+
+    let screen_image = with_ui_runtime_mut(|runtime| {
+        let row_index = runtime.media_row_index_by_key.get(media_key).copied()?;
+        let row = runtime.messages_model.row_data(row_index)?;
+        let mut image = row.media_image.clone();
+        if row.media_is_gif {
+            let now_ms = runtime.now_ms();
+            runtime
+                .gif_controller
+                .register_visibility_ping(media_key.to_owned(), now_ms);
+            if let Some(frame) = runtime.gif_controller.current_frame_for(media_key) {
+                image = frame;
+            }
+            runtime.fullscreen_media_key = Some(media_key.to_owned());
+        } else {
+            runtime.fullscreen_media_key = None;
+        }
+        Some(image)
+    })
+    .flatten();
+
+    if let Some(image) = screen_image {
+        ui.set_media_screen_image(image);
+        ui.set_show_media_screen(true);
+    }
+}
+
+fn close_media_screen(ui: &MainWindow) {
+    let _ = with_ui_runtime_mut(|runtime| {
+        runtime.fullscreen_media_key = None;
+    });
+    ui.set_show_media_screen(false);
+}
+
+fn run_gif_scheduler_tick(ui: &MainWindow) {
+    let mut fullscreen_image = None;
+    let _ = with_ui_runtime_mut(|runtime| {
+        let now_ms = runtime.now_ms();
+        if let Some(media_key) = runtime.fullscreen_media_key.clone() {
+            runtime
+                .gif_controller
+                .register_visibility_ping(media_key, now_ms);
+        }
+
+        for update in runtime.gif_controller.tick(now_ms) {
+            let Some(row_index) = runtime
+                .media_row_index_by_key
+                .get(&update.media_key)
+                .copied()
+            else {
+                continue;
+            };
+            let Some(mut row) = runtime.messages_model.row_data(row_index) else {
+                continue;
+            };
+            row.media_image = update.frame.clone();
+            row.has_media_image = true;
+            runtime.messages_model.set_row_data(row_index, row);
+
+            if runtime.fullscreen_media_key.as_deref() == Some(update.media_key.as_str()) {
+                fullscreen_image = Some(update.frame);
+            }
+        }
+
+        if fullscreen_image.is_none()
+            && let Some(media_key) = runtime.fullscreen_media_key.as_deref()
+        {
+            fullscreen_image = runtime.gif_controller.current_frame_for(media_key);
+        }
+    });
+
+    if let Some(image) = fullscreen_image {
+        ui.set_media_screen_image(image);
+    }
 }
 
 fn apply_snapshot_to_ui(ui: &MainWindow, snapshot: DesktopSnapshot) {
@@ -283,8 +473,33 @@ fn apply_snapshot_to_ui(ui: &MainWindow, snapshot: DesktopSnapshot) {
         has_error = snapshot.error_text.is_some(),
         "applying snapshot to ui"
     );
-    let rooms = snapshot
-        .rooms
+    let DesktopSnapshot {
+        rooms,
+        messages,
+        selected_room_id,
+        status_text,
+        error_text,
+        can_send,
+        show_login_screen,
+        login_homeserver,
+        login_user_id,
+        login_password,
+        login_remember_password,
+        login_in_flight,
+        show_logout_confirm,
+        show_security_dialog,
+        security_dialog_title,
+        security_dialog_body,
+        security_show_copy_button,
+        security_copy_button_text,
+        security_show_restore_input,
+        security_restore_button_text,
+        security_restore_in_flight,
+        composer_attachment,
+        ..
+    } = snapshot;
+
+    let rooms = rooms
         .into_iter()
         .map(|room| RoomRow {
             room_id: room.room_id.into(),
@@ -308,62 +523,142 @@ fn apply_snapshot_to_ui(ui: &MainWindow, snapshot: DesktopSnapshot) {
         })
         .collect::<Vec<_>>();
 
-    let messages = snapshot
-        .messages
-        .into_iter()
-        .map(|message| {
-            let media_image = message
-                .media_cached_path
-                .as_deref()
-                .and_then(|path| slint::Image::load_from_path(std::path::Path::new(path)).ok());
-            MessageRow {
-                event_id: message.event_id.unwrap_or_default().into(),
-                local_id: message.local_id.unwrap_or_default().into(),
-                sender: message.sender.into(),
-                body: message.body.into(),
-                event_kind: message.event_kind.into(),
-                caption: message.caption.into(),
-                media_status: message.media_status.into(),
-                media_source: message.media_source.unwrap_or_default().into(),
-                media_cached_path: message.media_cached_path.unwrap_or_default().into(),
-                has_media_image: media_image.is_some(),
-                media_image: media_image.unwrap_or_default(),
-                can_retry: message.can_retry,
-                can_remove: message.can_remove,
-                is_own: message.is_own,
-            }
-        })
-        .collect::<Vec<_>>();
+    let (fullscreen_image, fullscreen_hidden) = with_ui_runtime_mut(|runtime| {
+        let mut media_row_index_by_key = HashMap::new();
+        let mut active_gif_keys = HashSet::new();
+        let mapped_messages = messages
+            .into_iter()
+            .enumerate()
+            .map(|(row_index, message)| {
+                let mut media_image = message
+                    .media_cached_path
+                    .as_deref()
+                    .and_then(load_media_image_from_path);
+                let mut media_hint = message.media_hint.unwrap_or_default();
 
-    let error_text = snapshot.error_text.unwrap_or_default();
+                if message.event_kind == "image"
+                    && message.media_is_gif
+                    && !message.media_key.is_empty()
+                    && message.media_cached_path.is_some()
+                {
+                    let media_key = message.media_key.clone();
+                    let cached_path = message.media_cached_path.clone().unwrap_or_default();
+                    active_gif_keys.insert(media_key.clone());
+
+                    let should_attach = runtime
+                        .attached_gif_sources
+                        .get(&media_key)
+                        .map(|path| path != &cached_path)
+                        .unwrap_or(true);
+                    if should_attach {
+                        runtime
+                            .gif_controller
+                            .attach_source(media_key.clone(), Path::new(&cached_path));
+                        runtime
+                            .attached_gif_sources
+                            .insert(media_key.clone(), cached_path);
+                    }
+
+                    if let Some(frame) = runtime.gif_controller.current_frame_for(&media_key) {
+                        media_image = Some(frame);
+                    }
+                    if media_hint.is_empty()
+                        && let Some(hint) = runtime.gif_controller.hint_for(&media_key)
+                    {
+                        media_hint = hint;
+                    }
+                }
+
+                if !message.media_key.is_empty() {
+                    media_row_index_by_key.insert(message.media_key.clone(), row_index);
+                }
+
+                MessageRow {
+                    event_id: message.event_id.unwrap_or_default().into(),
+                    local_id: message.local_id.unwrap_or_default().into(),
+                    sender: message.sender.into(),
+                    body: message.body.into(),
+                    event_kind: message.event_kind.into(),
+                    caption: message.caption.into(),
+                    media_status: message.media_status.into(),
+                    media_source: message.media_source.unwrap_or_default().into(),
+                    media_cached_path: message.media_cached_path.unwrap_or_default().into(),
+                    media_key: message.media_key.into(),
+                    media_is_gif: message.media_is_gif,
+                    media_hint: media_hint.into(),
+                    has_media_image: media_image.is_some(),
+                    media_image: media_image.unwrap_or_default(),
+                    can_retry: message.can_retry,
+                    can_remove: message.can_remove,
+                    is_own: message.is_own,
+                }
+            })
+            .collect::<Vec<_>>();
+
+        runtime
+            .attached_gif_sources
+            .retain(|media_key, _| active_gif_keys.contains(media_key));
+        runtime.media_row_index_by_key = media_row_index_by_key;
+        runtime.messages_model.set_vec(mapped_messages);
+
+        let fullscreen_hidden = runtime
+            .fullscreen_media_key
+            .as_ref()
+            .is_some_and(|media_key| !runtime.media_row_index_by_key.contains_key(media_key));
+        if fullscreen_hidden {
+            runtime.fullscreen_media_key = None;
+        }
+
+        let fullscreen_image = runtime
+            .fullscreen_media_key
+            .as_deref()
+            .and_then(|media_key| runtime.gif_controller.current_frame_for(media_key));
+
+        (fullscreen_image, fullscreen_hidden)
+    })
+    .unwrap_or_else(|| {
+        warn!("ui runtime state not initialized while applying snapshot");
+        (None, false)
+    });
+
+    let error_text = error_text.unwrap_or_default();
 
     ui.set_rooms(slint::ModelRc::new(slint::VecModel::from(rooms)));
-    ui.set_messages(slint::ModelRc::new(slint::VecModel::from(messages)));
-    ui.set_selected_room_id(snapshot.selected_room_id.unwrap_or_default().into());
-    ui.set_status_text(snapshot.status_text.into());
+    ui.set_selected_room_id(selected_room_id.unwrap_or_default().into());
+    ui.set_status_text(status_text.into());
     ui.set_error_text(error_text.clone().into());
     ui.set_has_error(!error_text.is_empty());
-    ui.set_can_send(snapshot.can_send);
-    ui.set_show_login_screen(snapshot.show_login_screen);
-    ui.set_login_homeserver(snapshot.login_homeserver.into());
-    ui.set_login_user_id(snapshot.login_user_id.into());
-    ui.set_login_password(snapshot.login_password.into());
-    ui.set_login_remember_password(snapshot.login_remember_password);
-    ui.set_login_in_flight(snapshot.login_in_flight);
-    ui.set_show_logout_confirm(snapshot.show_logout_confirm);
-    if let Some(attachment) = snapshot.composer_attachment {
+    ui.set_can_send(can_send);
+    ui.set_show_login_screen(show_login_screen);
+    ui.set_login_homeserver(login_homeserver.into());
+    ui.set_login_user_id(login_user_id.into());
+    ui.set_login_password(login_password.into());
+    ui.set_login_remember_password(login_remember_password);
+    ui.set_login_in_flight(login_in_flight);
+    ui.set_show_logout_confirm(show_logout_confirm);
+    if let Some(attachment) = composer_attachment {
         ui.set_composer_attachment_name(attachment.file_name.into());
         ui.set_has_composer_attachment(true);
     } else {
         ui.set_composer_attachment_name("".into());
         ui.set_has_composer_attachment(false);
     }
-    ui.set_show_security_screen(snapshot.show_security_dialog);
-    ui.set_security_title(snapshot.security_dialog_title.into());
-    ui.set_security_body(snapshot.security_dialog_body.into());
-    ui.set_security_show_copy_button(snapshot.security_show_copy_button);
-    ui.set_security_copy_button_text(snapshot.security_copy_button_text.into());
-    ui.set_security_show_restore_input(snapshot.security_show_restore_input);
-    ui.set_security_restore_button_text(snapshot.security_restore_button_text.into());
-    ui.set_security_restore_in_flight(snapshot.security_restore_in_flight);
+    ui.set_show_security_screen(show_security_dialog);
+    ui.set_security_title(security_dialog_title.into());
+    ui.set_security_body(security_dialog_body.into());
+    ui.set_security_show_copy_button(security_show_copy_button);
+    ui.set_security_copy_button_text(security_copy_button_text.into());
+    ui.set_security_show_restore_input(security_show_restore_input);
+    ui.set_security_restore_button_text(security_restore_button_text.into());
+    ui.set_security_restore_in_flight(security_restore_in_flight);
+
+    if fullscreen_hidden {
+        ui.set_show_media_screen(false);
+    } else if let Some(image) = fullscreen_image {
+        ui.set_media_screen_image(image);
+    }
+}
+
+fn load_media_image_from_path(path: &str) -> Option<slint::Image> {
+    slint::Image::load_from_path(Path::new(path)).ok()
 }

--- a/apps/pikachat-desktop/src/media_cache.rs
+++ b/apps/pikachat-desktop/src/media_cache.rs
@@ -1,0 +1,234 @@
+//! Disk-backed media cache with JSON metadata index and LRU eviction.
+
+use std::{
+    collections::HashMap,
+    fs,
+    hash::{Hash, Hasher},
+    io,
+    path::{Path, PathBuf},
+    time::{SystemTime, UNIX_EPOCH},
+};
+
+use serde::{Deserialize, Serialize};
+
+const MEDIA_CACHE_DIR: &str = "media-cache";
+const INDEX_FILE: &str = "index.json";
+const DEFAULT_CAPACITY_BYTES: u64 = 1_024 * 1_024 * 1_024;
+
+#[derive(Debug, Clone)]
+pub struct MediaCache {
+    root: PathBuf,
+    index_path: PathBuf,
+    capacity_bytes: u64,
+    index: CacheIndex,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+struct CacheIndex {
+    entries: HashMap<String, CacheEntry>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct CacheEntry {
+    key: String,
+    path: String,
+    size: u64,
+    last_access_ms: u64,
+}
+
+impl MediaCache {
+    pub fn new(data_dir: &Path) -> io::Result<Self> {
+        Self::with_capacity(data_dir, DEFAULT_CAPACITY_BYTES)
+    }
+
+    pub fn with_capacity(data_dir: &Path, capacity_bytes: u64) -> io::Result<Self> {
+        let root = data_dir.join(MEDIA_CACHE_DIR);
+        fs::create_dir_all(&root)?;
+        let index_path = root.join(INDEX_FILE);
+        let index = load_index(&index_path).unwrap_or_default();
+
+        let mut cache = Self {
+            root,
+            index_path,
+            capacity_bytes: capacity_bytes.max(1),
+            index,
+        };
+        cache.prune_missing_files();
+        cache.evict_if_needed(None)?;
+        cache.persist_index()?;
+        Ok(cache)
+    }
+
+    pub fn get(&mut self, key: &str) -> Option<PathBuf> {
+        let now = now_millis();
+        let mut remove_stale_entry = false;
+        let path = {
+            let entry = self.index.entries.get_mut(key)?;
+            let path = self.root.join(&entry.path);
+            if !path.exists() {
+                None
+            } else if path
+                .extension()
+                .and_then(|ext| ext.to_str())
+                .is_some_and(|ext| ext.eq_ignore_ascii_case("bin"))
+            {
+                let _ = fs::remove_file(&path);
+                remove_stale_entry = true;
+                None
+            } else {
+                entry.last_access_ms = now;
+                Some(path)
+            }
+        };
+
+        if remove_stale_entry {
+            self.index.entries.remove(key);
+            let _ = self.persist_index();
+            return None;
+        }
+        let path = path?;
+        let _ = self.persist_index();
+        Some(path)
+    }
+
+    pub fn insert(
+        &mut self,
+        key: &str,
+        bytes: &[u8],
+        content_type: Option<&str>,
+    ) -> io::Result<PathBuf> {
+        let ext = extension_from_content_type(content_type)
+            .or_else(|| extension_from_bytes(bytes))
+            .ok_or_else(|| {
+                io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    "unsupported image format; expected png/jpeg/gif/webp bytes",
+                )
+            })?;
+        let stem = format!("{:016x}", stable_hash(key));
+        let file_name = format!("{stem}.{ext}");
+        let relative_path = PathBuf::from(file_name);
+        let absolute_path = self.root.join(&relative_path);
+
+        // Remove stale siblings for the same hash with different extensions.
+        for entry in fs::read_dir(&self.root)? {
+            let entry = entry?;
+            let path = entry.path();
+            if path == absolute_path || !path.is_file() {
+                continue;
+            }
+            let Some(name) = path.file_name().and_then(|name| name.to_str()) else {
+                continue;
+            };
+            if name == INDEX_FILE || !name.starts_with(&stem) || !name[stem.len()..].starts_with('.') {
+                continue;
+            }
+            match fs::remove_file(&path) {
+                Ok(()) => {}
+                Err(err) if err.kind() == io::ErrorKind::NotFound => {}
+                Err(err) => return Err(err),
+            }
+        }
+
+        fs::write(&absolute_path, bytes)?;
+
+        self.index.entries.insert(
+            key.to_owned(),
+            CacheEntry {
+                key: key.to_owned(),
+                path: relative_path.to_string_lossy().to_string(),
+                size: bytes.len() as u64,
+                last_access_ms: now_millis(),
+            },
+        );
+
+        self.evict_if_needed(Some(key))?;
+        self.persist_index()?;
+        Ok(absolute_path)
+    }
+
+    fn evict_if_needed(&mut self, protected_key: Option<&str>) -> io::Result<()> {
+        while self.total_size_bytes() > self.capacity_bytes {
+            let Some(evict_key) = self
+                .index
+                .entries
+                .values()
+                .filter(|entry| Some(entry.key.as_str()) != protected_key)
+                .min_by_key(|entry| entry.last_access_ms)
+                .map(|entry| entry.key.clone())
+            else {
+                break;
+            };
+
+            if let Some(entry) = self.index.entries.remove(&evict_key) {
+                let path = self.root.join(entry.path);
+                match fs::remove_file(path) {
+                    Ok(()) => {}
+                    Err(err) if err.kind() == io::ErrorKind::NotFound => {}
+                    Err(err) => return Err(err),
+                }
+            }
+        }
+        Ok(())
+    }
+
+    fn prune_missing_files(&mut self) {
+        self.index
+            .entries
+            .retain(|_, entry| self.root.join(&entry.path).exists());
+    }
+
+    fn total_size_bytes(&self) -> u64 {
+        self.index.entries.values().map(|entry| entry.size).sum()
+    }
+
+    fn persist_index(&self) -> io::Result<()> {
+        let encoded = serde_json::to_vec_pretty(&self.index)
+            .map_err(|err| io::Error::other(err.to_string()))?;
+        fs::write(&self.index_path, encoded)
+    }
+}
+
+fn load_index(path: &Path) -> Option<CacheIndex> {
+    let bytes = fs::read(path).ok()?;
+    serde_json::from_slice::<CacheIndex>(&bytes).ok()
+}
+
+fn extension_from_content_type(content_type: Option<&str>) -> Option<&'static str> {
+    match content_type?.to_ascii_lowercase().as_str() {
+        "image/jpeg" | "image/jpg" => Some("jpg"),
+        "image/png" => Some("png"),
+        "image/gif" => Some("gif"),
+        "image/webp" => Some("webp"),
+        _ => None,
+    }
+}
+
+fn extension_from_bytes(bytes: &[u8]) -> Option<&'static str> {
+    if bytes.len() >= 8 && bytes[0..8] == [0x89, b'P', b'N', b'G', 0x0D, 0x0A, 0x1A, 0x0A] {
+        return Some("png");
+    }
+    if bytes.len() >= 3 && bytes[0..3] == [0xFF, 0xD8, 0xFF] {
+        return Some("jpg");
+    }
+    if bytes.len() >= 6 && (&bytes[0..6] == b"GIF87a" || &bytes[0..6] == b"GIF89a") {
+        return Some("gif");
+    }
+    if bytes.len() >= 12 && &bytes[0..4] == b"RIFF" && &bytes[8..12] == b"WEBP" {
+        return Some("webp");
+    }
+    None
+}
+
+fn stable_hash(key: &str) -> u64 {
+    let mut hasher = std::collections::hash_map::DefaultHasher::new();
+    key.hash(&mut hasher);
+    hasher.finish()
+}
+
+fn now_millis() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|duration| duration.as_millis() as u64)
+        .unwrap_or(0)
+}

--- a/apps/pikachat-desktop/ui/main.slint
+++ b/apps/pikachat-desktop/ui/main.slint
@@ -23,6 +23,9 @@ export struct MessageRow {
     media_status: string,
     media_source: string,
     media_cached_path: string,
+    media_key: string,
+    media_is_gif: bool,
+    media_hint: string,
     media_image: image,
     has_media_image: bool,
     can_retry: bool,
@@ -57,6 +60,9 @@ export component MainWindow inherits Window {
     callback media-retry-requested(source: string);
     callback outgoing-media-retry-requested(local_id: string);
     callback outgoing-media-remove-requested(local_id: string);
+    callback gif-visible-ping(media_key: string);
+    callback media-screen-open-requested(media_key: string);
+    callback media-screen-close-requested();
     callback timeline-scrolled(viewport_y: float);
     callback sidebar-width-requested(width_px: float, window_width_px: float);
 
@@ -388,10 +394,22 @@ export component MainWindow inherits Window {
                             overflow: elide;
                         }
 
-                        if message.event_kind == "image" : VerticalLayout {
+                        gif-visible-timer := Timer {
+                            interval: 250ms;
+                            running: message.event_kind == "image"
+                                && message.media_is_gif
+                                && message.has_media_image
+                                && message.media_key != "";
+                            triggered => {
+                                root.gif-visible-ping(message.media_key);
+                            }
+                        }
+
+                        image-content := VerticalLayout {
                             x: 12px;
                             y: sender.y + sender.height + 6px;
                             width: parent.width - 24px;
+                            visible: message.event_kind == "image";
                             spacing: 6px;
 
                             if message.has_media_image : Image {
@@ -404,8 +422,7 @@ export component MainWindow inherits Window {
                                     width: parent.width;
                                     height: parent.height;
                                     clicked => {
-                                        root.media-screen-image = message.media_image;
-                                        root.show-media-screen = true;
+                                        root.media-screen-open-requested(message.media_key);
                                     }
                                 }
                             }
@@ -441,6 +458,14 @@ export component MainWindow inherits Window {
                             if message.caption != "" : Text {
                                 text: message.caption;
                                 color: #f2f6ff;
+                                wrap: word-wrap;
+                                horizontal-alignment: left;
+                            }
+
+                            if message.media_hint != "" : Text {
+                                text: message.media_hint;
+                                color: #9eb2dc;
+                                font-size: 12px;
                                 wrap: word-wrap;
                                 horizontal-alignment: left;
                             }
@@ -911,7 +936,7 @@ export component MainWindow inherits Window {
             width: parent.width;
             height: parent.height;
             clicked => {
-                root.show-media-screen = false;
+                root.media-screen-close-requested();
             }
         }
 

--- a/apps/pikachat-desktop/ui/main.slint
+++ b/apps/pikachat-desktop/ui/main.slint
@@ -15,8 +15,18 @@ export struct RoomRow {
 
 export struct MessageRow {
     event_id: string,
+    local_id: string,
     sender: string,
     body: string,
+    event_kind: string,
+    caption: string,
+    media_status: string,
+    media_source: string,
+    media_cached_path: string,
+    media_image: image,
+    has_media_image: bool,
+    can_retry: bool,
+    can_remove: bool,
     is_own: bool,
 }
 
@@ -42,6 +52,11 @@ export component MainWindow inherits Window {
     callback room-invite-accept-requested(room_id: string);
     callback room-invite-reject-requested(room_id: string);
     callback send-message-requested(text: string) -> bool;
+    callback attachment-pick-requested();
+    callback attachment-clear-requested();
+    callback media-retry-requested(source: string);
+    callback outgoing-media-retry-requested(local_id: string);
+    callback outgoing-media-remove-requested(local_id: string);
     callback timeline-scrolled(viewport_y: float);
     callback sidebar-width-requested(width_px: float, window_width_px: float);
 
@@ -63,6 +78,8 @@ export component MainWindow inherits Window {
     in-out property <bool> security-show-restore-input: false;
     in-out property <string> security-restore-button-text: "Restore";
     in-out property <bool> security-restore-in-flight: false;
+    in-out property <bool> show-media-screen: false;
+    in-out property <image> media-screen-image;
 
     in property <[RoomRow]> rooms;
     in property <[MessageRow]> messages;
@@ -71,6 +88,8 @@ export component MainWindow inherits Window {
     in property <string> error-text: "";
     in property <bool> has-error: false;
     in property <bool> can-send: false;
+    in property <string> composer-attachment-name: "";
+    in property <bool> has-composer-attachment: false;
 
     menu_bar := MenuBar {
         Menu {
@@ -369,7 +388,84 @@ export component MainWindow inherits Window {
                             overflow: elide;
                         }
 
-                        body := Text {
+                        if message.event_kind == "image" : VerticalLayout {
+                            x: 12px;
+                            y: sender.y + sender.height + 6px;
+                            width: parent.width - 24px;
+                            spacing: 6px;
+
+                            if message.has_media_image : Image {
+                                source: message.media_image;
+                                width: min(parent.width, 360px);
+                                height: 220px;
+                                image-fit: contain;
+
+                                TouchArea {
+                                    width: parent.width;
+                                    height: parent.height;
+                                    clicked => {
+                                        root.media-screen-image = message.media_image;
+                                        root.show-media-screen = true;
+                                    }
+                                }
+                            }
+
+                            if !message.has_media_image : Rectangle {
+                                width: parent.width;
+                                height: 88px;
+                                border-radius: 8px;
+                                border-width: 1px;
+                                border-color: #4a5772;
+                                background: #1b2332;
+
+                                Text {
+                                    x: 10px;
+                                    y: 12px;
+                                    width: parent.width - 20px;
+                                    text: "Image: " + message.media_status;
+                                    color: #d6e1ff;
+                                    overflow: elide;
+                                }
+
+                                if message.can_retry : Button {
+                                    x: parent.width - self.width - 10px;
+                                    y: parent.height - self.height - 10px;
+                                    width: 72px;
+                                    text: "Retry";
+                                    clicked => {
+                                        root.media-retry-requested(message.media_source);
+                                    }
+                                }
+                            }
+
+                            if message.caption != "" : Text {
+                                text: message.caption;
+                                color: #f2f6ff;
+                                wrap: word-wrap;
+                                horizontal-alignment: left;
+                            }
+
+                            if message.can_retry && message.local_id != "" : HorizontalLayout {
+                                spacing: 8px;
+
+                                Button {
+                                    text: "Retry";
+                                    width: 72px;
+                                    clicked => {
+                                        root.outgoing-media-retry-requested(message.local_id);
+                                    }
+                                }
+                                if message.can_remove : Button {
+                                    text: "Remove";
+                                    width: 86px;
+                                    clicked => {
+                                        root.outgoing-media-remove-requested(message.local_id);
+                                    }
+                                }
+                            }
+                        }
+
+                        if message.event_kind == "text" : Text {
                             x: 12px;
                             y: sender.y + sender.height + 6px;
                             width: parent.width - 24px;
@@ -379,7 +475,9 @@ export component MainWindow inherits Window {
                             horizontal-alignment: left;
                         }
 
-                        height: body.y + body.height + 10px;
+                        height: message.event_kind == "image"
+                            ? (sender.y + sender.height + 6px + 220px)
+                            : (sender.y + sender.height + 34px);
                     }
                 }
             }
@@ -405,7 +503,7 @@ export component MainWindow inherits Window {
                 input := TextEdit {
                     x: 10px;
                     y: 10px;
-                    width: parent.width - send-btn.width - 28px;
+                    width: parent.width - 220px;
                     height: parent.height - 20px;
                     text <=> root.composer-text;
                     enabled: root.can-send;
@@ -432,6 +530,45 @@ export component MainWindow inherits Window {
                     clicked => {
                         if (root.send-message-requested(root.composer-text)) {
                             root.composer-text = "";
+                        }
+                    }
+                }
+
+                attach-btn := Button {
+                    x: send-btn.x - self.width - 8px;
+                    y: (parent.height - self.height) / 2;
+                    width: 92px;
+                    text: "Attach";
+                    enabled: root.can-send;
+                    clicked => {
+                        root.attachment-pick-requested();
+                    }
+                }
+
+                if root.has-composer-attachment : Rectangle {
+                    x: 10px;
+                    y: parent.height - self.height - 8px;
+                    width: parent.width - 20px;
+                    height: 24px;
+                    border-radius: 6px;
+                    background: #24314a;
+
+                    Text {
+                        x: 8px;
+                        y: 4px;
+                        width: parent.width - clear-attachment-btn.width - 20px;
+                        text: "Attachment: " + root.composer-attachment-name;
+                        color: #d6e1ff;
+                        overflow: elide;
+                    }
+
+                    clear-attachment-btn := Button {
+                        x: parent.width - self.width - 6px;
+                        y: 1px;
+                        width: 56px;
+                        text: "Clear";
+                        clicked => {
+                            root.attachment-clear-requested();
                         }
                     }
                 }
@@ -760,6 +897,31 @@ export component MainWindow inherits Window {
                     root.security-dialog-dismissed();
                 }
             }
+        }
+    }
+
+    if root.show-media-screen : Rectangle {
+        x: 0;
+        y: 0;
+        width: parent.width;
+        height: parent.height;
+        background: #000000cc;
+
+        TouchArea {
+            width: parent.width;
+            height: parent.height;
+            clicked => {
+                root.show-media-screen = false;
+            }
+        }
+
+        Image {
+            x: 24px;
+            y: 24px;
+            width: parent.width - 48px;
+            height: parent.height - 48px;
+            source: root.media-screen-image;
+            image-fit: contain;
         }
     }
 }

--- a/crates/backend-core/src/lib.rs
+++ b/crates/backend-core/src/lib.rs
@@ -26,7 +26,8 @@ pub use state_machine::BackendStateMachine;
 pub use timeline::{TimelineBuffer, TimelineMergeError};
 pub use types::{
     BackendCommand, BackendEvent, BackendInitConfig, BackendLifecycleState, CryptoStatus,
-    KeyBackupState, MediaDownloadAck, MediaUploadAck, MessageType, RecoveryEnableAck,
-    RecoveryRestoreAck, RecoveryState, RecoveryStatus, RoomSummary, SendAck, SyncStatus,
-    TimelineItem, TimelineOp,
+    EncryptedFileSource, KeyBackupState, MediaDownloadAck, MediaSourceRef, MediaUploadAck,
+    MessageType, OutgoingMedia, RecoveryEnableAck, RecoveryRestoreAck, RecoveryState,
+    RecoveryStatus, RoomSummary, SendAck, SyncStatus, TimelineContent, TimelineImageContent,
+    TimelineImageMetadata, TimelineItem, TimelineOp,
 };

--- a/crates/backend-core/src/state_machine.rs
+++ b/crates/backend-core/src/state_machine.rs
@@ -74,6 +74,7 @@ impl BackendStateMachine {
             | PaginateBack { .. }
             | SendDmText { .. }
             | SendMessage { .. }
+            | SendMediaMessage { .. }
             | EditMessage { .. }
             | RedactMessage { .. }
             | UploadMedia { .. }


### PR DESCRIPTION
## Summary
- add backend timeline/media primitives and encrypted media download support
- add desktop media cache, attachment send flow, and retry/remove handling for outgoing media
- render timeline image media from cached files in the desktop UI
- add visibility-gated GIF playback with decode guardrails and fallback behavior

## Validation
- cargo test -p backend-core -p backend-matrix -p pikachat-desktop

Closes #4